### PR TITLE
Update resume-openfont.cls

### DIFF
--- a/resume-openfont.cls
+++ b/resume-openfont.cls
@@ -129,7 +129,7 @@
 
 % Underlined link command
 \newcommand{\underlinedLink}[2]{%
-\uline{\href{#1}{#2}}%
+\href{#1}{\uline{#2}}%
 }
 
 % Command for table 


### PR DESCRIPTION
`\uline` outside `\href{}{}` does not break the line on very long inputs. Moving the `\uline` inside the second parameter solves this issue.